### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Traditional approaches fail because:
 - Prepaid credits = budget controlled by humans
 - Single provider = no choice, no optimization
 
-The x402 protocol solves this by making payments as simple as HTTP requests. BlockRun brings this to AI - <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, pay-per-request, no keys needed.
+The x402 protocol solves this by making payments as simple as HTTP requests. BlockRun brings this to AI - <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, pay-per-request, no keys needed.
 
 **This agent is our proof that autonomous AI economies are possible today.**
 
@@ -951,7 +951,7 @@ We're building the infrastructure for autonomous AI economies. This agent is jus
 
 ## About BlockRun.AI
 
-[BlockRun](https://blockrun.ai) is the gateway to AI services using x402 micropayments. Access <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models with just a wallet - no API keys needed.
+[BlockRun](https://blockrun.ai) is the gateway to AI services using x402 micropayments. Access <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> AI models with just a wallet - no API keys needed.
 
 **Connect with us:**
 

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 66,
-    "totalVisible": 86,
-    "free": 8,
-    "freeWithheld": 17,
-    "image": 8,
+    "chatVisible": 71,
+    "totalVisible": 92,
+    "free": 6,
+    "freeWithheld": 19,
+    "image": 9,
     "video": 5,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 44,
-    "withFallbackAllEntries": 75
+    "withFallback": 46,
+    "withFallbackAllEntries": 79
   },
   "clawrouter": {
     "dimensions": 15,
@@ -21,7 +21,7 @@
     "aliases": 202
   },
   "mcp": {
-    "tools": 19
+    "tools": 20
   },
   "chains": {
     "rpc": 40


### PR DESCRIPTION
`brand-numbers.json` in this repo was a catalog generation behind, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. **Nothing refreshes that input.** `sync-brand-numbers.mjs` reads the local snapshot and only re-fetches under `--refresh`; `--check` is offline by design so PR CI stays deterministic. The script header defers freshness to a fan-out job that was never built, so all 15 consumers have been validating markers against their own stale copies and reporting green.

Measured across the org on 2026-08-05: **14 of 15 consumers stale**, most at 66/86/8, ClawRouter at 65/85/7. Truth is **71 chat / 92 total / 6 free**. Only ClawRouter-Hermes was current.

Produced by `node scripts/sync-brand-numbers.mjs --refresh` — no hand-edited digits.

The mirror (BlockRunAI/awesome-blockrun#34) is refreshed first, since it is what every other repo falls back to. The fan-out job itself follows in BlockRunAI/blockrun.