### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Traditional approaches fail because:
 - Prepaid credits = budget controlled by humans
 - Single provider = no choice, no optimization
 
-The x402 protocol solves this by making payments as simple as HTTP requests. BlockRun brings this to AI - <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, pay-per-request, no keys needed.
+The x402 protocol solves this by making payments as simple as HTTP requests. BlockRun brings this to AI - <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, pay-per-request, no keys needed.
 
 **This agent is our proof that autonomous AI economies are possible today.**
 
@@ -951,7 +951,7 @@ We're building the infrastructure for autonomous AI economies. This agent is jus
 
 ## About BlockRun.AI
 
-[BlockRun](https://blockrun.ai) is the gateway to AI services using x402 micropayments. Access <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> AI models with just a wallet - no API keys needed.
+[BlockRun](https://blockrun.ai) is the gateway to AI services using x402 micropayments. Access <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> AI models with just a wallet - no API keys needed.
 
 **Connect with us:**
 

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 71,
-    "totalVisible": 95,
-    "free": 5,
-    "freeWithheld": 20,
+    "chatVisible": 76,
+    "totalVisible": 100,
+    "free": 7,
+    "freeWithheld": 26,
     "image": 9,
     "video": 8,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 44,
-    "withFallbackAllEntries": 78
+    "withFallback": 48,
+    "withFallbackAllEntries": 89
   },
   "clawrouter": {
     "dimensions": 15,
@@ -29,6 +29,6 @@
   "savings": {
     "baselineModel": "anthropic/claude-opus-5",
     "ecoVsBaselinePct": 98,
-    "autoVsBaselinePct": 88
+    "autoVsBaselinePct": 84
   }
 }


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.